### PR TITLE
Added a check if the player is holding his left click

### DIFF
--- a/gs_switcher.lua
+++ b/gs_switcher.lua
@@ -50,6 +50,7 @@ local math_floor = math.floor
 local string_sub = string.sub
 local LocalPlayer = LocalPlayer
 local string_lower = string.lower
+local input_IsMouseDown = input.IsMouseDown
 local input_SelectWeapon = input.SelectWeapon
 
 -- Hide the default weapon selection
@@ -160,7 +161,7 @@ hook_Add("HUDPaint", "GS_WeaponSelector", function()
 end)
 
 hook_Add("PlayerBindPress", "GS_WeaponSelector", function(pPlayer, sBind, bPressed)
-	if (not pPlayer:Alive() or pPlayer:InVehicle() and not pPlayer:GetAllowWeaponsInVehicle()) then
+	if (not pPlayer:Alive() or input_IsMouseDown(MOUSE_LEFT) or pPlayer:InVehicle() and not pPlayer:GetAllowWeaponsInVehicle()) then
 		return
 	end
 


### PR DESCRIPTION
This avoids unwanted changes of weapons such as when manipulating the physgun. The only issue for me here is that it doesn't check if the bind `+attack` but the left click is pretty arbitrary, but for a very large part of Garry's Mod players this is the case. I looked for a better way with the `input.*` functions but without great result. If you suggest a better way, I'm in.

This closes #5.